### PR TITLE
Improve 'korecli rm' command

### DIFF
--- a/korecli/cmd/create.go
+++ b/korecli/cmd/create.go
@@ -175,11 +175,11 @@ func (d *createData) createRepository(path string) error {
 		return err
 	}
 
-	repoFile, err := os.Create(fmt.Sprintf("%s/greet_repository.go", repoPath))
+	repoFile, err := os.Create(fmt.Sprintf("%s/%s_repository.go", repoPath, d.ServiceName))
 	if err != nil {
 		return err
 	}
-	repoTpl := template.Must(template.New("greet_repository").Parse(string(tpl.RepoTemplate())))
+	repoTpl := template.Must(template.New("repository").Parse(string(tpl.RepoTemplate())))
 	if err := repoTpl.Execute(repoFile, d); err != nil {
 		return err
 	}
@@ -203,11 +203,11 @@ func (d *createData) createUsecase(path string) error {
 		return err
 	}
 
-	usecaseFile, err := os.Create(fmt.Sprintf("%s/greet_usecase.go", usecasePath))
+	usecaseFile, err := os.Create(fmt.Sprintf("%s/%s_usecase.go", usecasePath, d.ServiceName))
 	if err != nil {
 		return err
 	}
-	usecaseTpl := template.Must(template.New("greet_usecase").Parse(string(tpl.UsecaseTemplate())))
+	usecaseTpl := template.Must(template.New("usecase").Parse(string(tpl.UsecaseTemplate())))
 	if err := usecaseTpl.Execute(usecaseFile, d); err != nil {
 		return err
 	}
@@ -231,11 +231,11 @@ func (d *createData) createService(path string) error {
 		return err
 	}
 
-	serviceFile, err := os.Create(fmt.Sprintf("%s/greet_service.go", servicePath))
+	serviceFile, err := os.Create(fmt.Sprintf("%s/%s_service.go", servicePath, d.ServiceName))
 	if err != nil {
 		return err
 	}
-	serviceTpl := template.Must(template.New("greet_service").Parse(string(tpl.ServiceTemplate())))
+	serviceTpl := template.Must(template.New("service").Parse(string(tpl.ServiceTemplate())))
 	if err := serviceTpl.Execute(serviceFile, d); err != nil {
 		return err
 	}

--- a/korecli/cmd/remove.go
+++ b/korecli/cmd/remove.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -58,19 +59,27 @@ func (d *removeData) removeProto() error {
 	if _, err := os.Stat(protoPath); err != nil {
 		return err
 	}
-	if err := os.Remove(fmt.Sprintf("%s/%s.proto", protoPath, d.ServiceName)); err != nil {
+	if err := removeIfExist(fmt.Sprintf("%s/%s.proto", protoPath, d.ServiceName)); err != nil {
 		return err
 	}
-	if err := os.Remove(fmt.Sprintf("%s/%s.pb.go", protoPath, d.ServiceName)); err != nil {
+	if err := removeIfExist(fmt.Sprintf("%s/%s.pb.go", protoPath, d.ServiceName)); err != nil {
 		return err
 	}
-	if err := os.Remove(fmt.Sprintf("%s/%s.pb.gw.go", protoPath, d.ServiceName)); err != nil {
+	if err := removeIfExist(fmt.Sprintf("%s/%s.pb.gw.go", protoPath, d.ServiceName)); err != nil {
 		return err
 	}
-	if err := os.Remove(fmt.Sprintf("%s/%s_grpc.pb.go", protoPath, d.ServiceName)); err != nil {
+	if err := removeIfExist(fmt.Sprintf("%s/%s_grpc.pb.go", protoPath, d.ServiceName)); err != nil {
 		return err
 	}
 	return nil
+}
+
+func removeIfExist(filename string) error {
+	err := os.Remove(filename)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }
 
 func (d *removeData) removeService() error {

--- a/korecli/cmd/remove.go
+++ b/korecli/cmd/remove.go
@@ -17,9 +17,10 @@ and '/libs/proto/v1/todo.proto' file with all the proto generated files.
 
 func newRemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rm SERVICE",
-		Short: "Remove a service",
-		Long:  removeDesc,
+		Use:     "remove SERVICE",
+		Short:   "Remove a service",
+		Long:    removeDesc,
+		Aliases: []string{"rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			wd, err := os.Getwd()
 			if err != nil {

--- a/korecli/cmd/root.go
+++ b/korecli/cmd/root.go
@@ -11,7 +11,7 @@ const koreDesc = `Monorepo CLI tool
 Action for CLI:
 
 - korecli create: create new service
-- korecli rm:     remove a service
+- korecli remove: remove a service
 `
 
 func newRootCmd() *cobra.Command {

--- a/korecli/tpl/repository.go
+++ b/korecli/tpl/repository.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/wire"
 )
 
-var ProviderSet = wire.NewSet(NewGreetRepository)
+var ProviderSet = wire.NewSet(New{{ .StructName }}Repository)
 `)
 }
 
@@ -21,14 +21,14 @@ import (
 	"{{ .Mod }}/libs/repository"
 )
 
-type greetRepo struct {
+type {{ .ServiceName }}Repo struct {
 }
 
-func NewGreetRepository() repository.Greeter {
-	return &greetRepo{}
+func New{{ .StructName }}Repository() repository.Greeter {
+	return &{{ .ServiceName }}Repo{}
 }
 
-func (r *greetRepo) Get(ctx context.Context) (*model.Greet, error) {
+func (r *{{ .ServiceName }}Repo) Get(ctx context.Context) (*model.Greet, error) {
 	return &model.Greet{}, nil
 }
 `)

--- a/korecli/tpl/service.go
+++ b/korecli/tpl/service.go
@@ -24,10 +24,10 @@ import (
 type {{ .StructName }}Service struct {
 	v1.Unimplemented{{ .StructName }}Server
 
-	uc *usecase.GreetUsecase
+	uc *usecase.{{ .StructName }}Usecase
 }
 
-func New{{ .StructName }}Service(uc *usecase.GreetUsecase) *{{ .StructName }}Service {
+func New{{ .StructName }}Service(uc *usecase.{{ .StructName }}Usecase) *{{ .StructName }}Service {
 	return &{{ .StructName }}Service{uc: uc}
 }
 

--- a/korecli/tpl/usecase.go
+++ b/korecli/tpl/usecase.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/wire"
 )
 
-var ProviderSet = wire.NewSet(NewGreetUsecase)
+var ProviderSet = wire.NewSet(New{{ .StructName }}Usecase)
 `)
 }
 
@@ -22,19 +22,19 @@ import (
 	"{{ .Mod }}/libs/repository"
 )
 
-type GreetUsecase struct {
+type {{ .StructName }}Usecase struct {
 	log  *log.Logger
 	repo repository.Greeter
 }
 
-func NewGreetUsecase(log *log.Logger, repo repository.Greeter) *GreetUsecase {
-	return &GreetUsecase{
+func New{{ .StructName }}Usecase(log *log.Logger, repo repository.Greeter) *{{ .StructName }}Usecase {
+	return &{{ .StructName }}Usecase{
 		log:  log,
 		repo: repo,
 	}
 }
 
-func (uc *GreetUsecase) Greet(ctx context.Context, req *v1.{{ .StructName }}Request) (*v1.{{ .StructName }}Reply, error) {
+func (uc *{{ .StructName }}Usecase) Greet(ctx context.Context, req *v1.{{ .StructName }}Request) (*v1.{{ .StructName }}Reply, error) {
 	uc.log.Usecase("Greet").Infof("Greet %s", req.GetName())
 	return &v1.{{ .StructName }}Reply{
 		Message: "Hello " + req.GetName(),


### PR DESCRIPTION
1. `korecli rm` now become `korecli remove` and `rm` become alias for `remove`.
2. `removeIfExist` function for check `remove` error.